### PR TITLE
Change permission of httpd.pid file.

### DIFF
--- a/includes/Clamp/ApacheCommand.php
+++ b/includes/Clamp/ApacheCommand.php
@@ -14,6 +14,7 @@ class ApacheCommand extends \Clamp\Command
             $this->preparePaths($options);
             exec($this->getConfig('$.apache.commands.httpd') . ' -f /dev/null ' . $this->buildParameters($options) . ' > /dev/null &');
             $this->waitFor($this->getPath($options['pidfile']));
+            exec('sudo chmod g+rwx ' . $this->getPath($options['pidfile']));
             $this->writeln('Apache server started', ConsoleKit\Colors::GREEN);
         }
         else {


### PR DESCRIPTION
Add read, write and execute rights for group. As the owner of the pid file is root, users get a problem if they have set their umask to 067, cause they no longer have the right to read the file and thus the included process id. As such the server will not be killed.