### PR TITLE
Update to PHP 7.2

### DIFF
--- a/clamp.defaults.json
+++ b/clamp.defaults.json
@@ -33,7 +33,7 @@
                 "mime_module": "/usr/libexec/apache2/mod_mime.so",
                 "log_config_module": "/usr/libexec/apache2/mod_log_config.so",
                 "rewrite_module": "/usr/libexec/apache2/mod_rewrite.so",
-                "php7_module": "/usr/libexec/apache2/libphp7.so",
+                "php7_module": "/usr/local/opt/php/lib/httpd/modules/libphp7.so",
                 "unixd_module": "/usr/libexec/apache2/mod_unixd.so"
             },
             "php_admin_value": "{{$.php.options}}"


### PR DESCRIPTION
I was getting an error when starting clamp on OS X El Capitan, so I figured out that the PHP 7.2 that I installed with Homebrew had to be manually configured, so I figured that it would be beneficial to add PHP 7.2 as a dependency, and change the module in the default config to match.

See my PR on [jide/homebrew-clamp #2](https://github.com/jide/homebrew-clamp/pull/2)