### PR TITLE
don't hardcode /usr/local/clamp path

### DIFF
--- a/clamp
+++ b/clamp
@@ -3,7 +3,6 @@
 set -e 
 
 # TODO: remove once https://github.com/jide/clamp/pull/32
-#       is landed to homebrew-clamp.
 # sacrificial find and replace: /usr/local/clamp
 
 start() {

--- a/clamp
+++ b/clamp
@@ -34,7 +34,7 @@ realpath_sh() {
 
 # get the directory this script is in
 SCRIPT_PATH="${BASH_SOURCE[0]}"
-RESOLVED_PATH=$(realpath_sh "$SCRIPT_PATH")
+RESOLVED_PATH=$(realpath_py "$SCRIPT_PATH")
 SCRIPT_DIR="$(dirname ${RESOLVED_PATH})"
 
 if [ "$#" == "0" ]; then

--- a/clamp
+++ b/clamp
@@ -19,9 +19,22 @@ realpath_py() {
     python -c "import os; print(os.path.realpath('$1'))"
 }
 
+realpath_sh() {
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}
+
 # get the directory this script is in
 SCRIPT_PATH="${BASH_SOURCE[0]}"
-RESOLVED_PATH=$(realpath_py "$SCRIPT_PATH")
+RESOLVED_PATH=$(realpath_sh "$SCRIPT_PATH")
 SCRIPT_DIR="$(dirname ${RESOLVED_PATH})"
 
 if [ "$#" == "0" ]; then

--- a/clamp
+++ b/clamp
@@ -4,7 +4,7 @@ set -e
 
 # TODO: remove once https://github.com/jide/clamp/pull/32
 #       is landed to homebrew-clamp.
-# sacrificial find and replace: /usr/local/bin
+# sacrificial find and replace: /usr/local/clamp
 
 start() {
     php ${SCRIPT_DIR}/clamp.php start

--- a/clamp
+++ b/clamp
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e 
+set -e
 
 # TODO: remove once https://github.com/jide/clamp/pull/32
 # sacrificial find and replace: /usr/local/clamp
@@ -8,7 +8,7 @@ set -e
 start() {
     php ${SCRIPT_DIR}/clamp.php start
 }
- 
+
 stop() {
     echo -en "\n"
     php ${SCRIPT_DIR}/clamp.php stop
@@ -20,16 +20,16 @@ realpath_py() {
 }
 
 realpath_sh() {
-  OURPWD=$PWD
-  cd "$(dirname "$1")"
-  LINK=$(readlink "$(basename "$1")")
-  while [ "$LINK" ]; do
-    cd "$(dirname "$LINK")"
+    OURPWD=$PWD
+    cd "$(dirname "$1")"
     LINK=$(readlink "$(basename "$1")")
-  done
-  REALPATH="$PWD/$(basename "$1")"
-  cd "$OURPWD"
-  echo "$REALPATH"
+    while [ "$LINK" ]; do
+        cd "$(dirname "$LINK")"
+        LINK=$(readlink "$(basename "$1")")
+    done
+    REALPATH="$PWD/$(basename "$1")"
+    cd "$OURPWD"
+    echo "$REALPATH"
 }
 
 # get the directory this script is in

--- a/clamp
+++ b/clamp
@@ -2,8 +2,11 @@
 
 set -e
 
-# TODO: remove once https://github.com/jide/clamp/pull/32
-# sacrificial find and replace: /usr/local/clamp
+# TODO: remove once a PR for homebrew-clamp lands that
+#       removes the find and replace. line below makes
+#       homebrew happy until then.
+# 
+# installation path: /usr/local/clamp
 
 start() {
     php ${SCRIPT_DIR}/clamp.php start

--- a/clamp
+++ b/clamp
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -e 
+
 # get the directory this script is in
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+DIR=`dirname $(realpath "${BASH_SOURCE[0]}")`
 
 start() {
     php ${DIR}/clamp.php start

--- a/clamp
+++ b/clamp
@@ -2,18 +2,28 @@
 
 set -e 
 
-# get the directory this script is in
-DIR=`dirname $(realpath "${BASH_SOURCE[0]}")`
+# TODO: remove once https://github.com/jide/clamp/pull/32
+#       is landed to homebrew-clamp.
+# sacrificial find and replace: /usr/local/bin
 
 start() {
-    php ${DIR}/clamp.php start
+    php ${SCRIPT_DIR}/clamp.php start
 }
  
 stop() {
     echo -en "\n"
-    php ${DIR}/clamp.php stop
+    php ${SCRIPT_DIR}/clamp.php stop
     exit $?
 }
+
+realpath_py() {
+    python -c "import os; print(os.path.realpath('$1'))"
+}
+
+# get the directory this script is in
+SCRIPT_PATH="${BASH_SOURCE[0]}"
+RESOLVED_PATH=$(realpath_py "$SCRIPT_PATH")
+SCRIPT_DIR="$(dirname ${RESOLVED_PATH})"
 
 if [ "$#" == "0" ]; then
     trap stop SIGINT
@@ -21,5 +31,5 @@ if [ "$#" == "0" ]; then
 
     while true; do read x; done
 else
-    php ${DIR}/clamp.php "$@"
+    php ${SCRIPT_DIR}/clamp.php "$@"
 fi

--- a/clamp
+++ b/clamp
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+# get the directory this script is in
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
 start() {
-    php /usr/local/clamp/clamp.php start
+    php ${DIR}/clamp.php start
 }
  
 stop() {
     echo -en "\n"
-    php /usr/local/clamp/clamp.php stop
+    php ${DIR}/clamp.php stop
     exit $?
 }
 
@@ -16,5 +19,5 @@ if [ "$#" == "0" ]; then
 
     while true; do read x; done
 else
-    php /usr/local/clamp/clamp.php "$@"
+    php ${DIR}/clamp.php "$@"
 fi


### PR DESCRIPTION
Hardcoding /usr/local/clamp makes development difficult and is unnecessary.

Tested by installing my homebrew tap (https://github.com/aerickson/homebrew-clamp) that uses my fork with this code. 

The find/replace in homebrew-clamp needs to be removed if/when this change is landed.