### PR TITLE
change default port from 80 to 9988

### DIFF
--- a/clamp.defaults.13.json
+++ b/clamp.defaults.13.json
@@ -8,7 +8,7 @@
         },
         "options": {
             "servername": "{{$.address}}",
-            "listen": "80",
+            "listen": "9988",
             "documentroot": "'{{$cwd}}'",
             "serverroot": "'{{$cwd}}'",
             "pidfile": "'{{$cwd}}/.clamp/tmp/httpd.pid'",

--- a/clamp.defaults.json
+++ b/clamp.defaults.json
@@ -11,7 +11,7 @@
             "AllowOverride": "All",
             "</Directory>": "",
             "servername": "{{$.address}}",
-            "listen": "80",
+            "listen": "9988",
             "documentroot": "'{{$cwd}}'",
             "serverroot": "'{{$cwd}}'",
             "pidfile": "'{{$cwd}}/.clamp/tmp/httpd.pid'",


### PR DESCRIPTION
- seems available per https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers

see https://github.com/jide/clamp/issues/41
